### PR TITLE
Clamp Geodesic cosine values

### DIFF
--- a/src/DistanceDist.h
+++ b/src/DistanceDist.h
@@ -131,10 +131,12 @@ class DistanceFJaccard : public IDistance {
 class DistanceGeodesic : public IDistance {
   public:
     double calcDistance(const arma::mat &A, const arma::mat &B) {
-        // arccos(xy / sqrt(xx * yy))
-        return acos(arma::dot(A.row(0), B.row(0)) /
-                    std::sqrt(arma::dot(A.row(0), A.row(0)) *
-                              arma::dot(B.row(0), B.row(0))));
+        // arccos(xy / sqrt(xx * yy)) with clamped cosine
+        double cosTheta = arma::dot(A.row(0), B.row(0)) /
+                          std::sqrt(arma::dot(A.row(0), A.row(0)) *
+                                    arma::dot(B.row(0), B.row(0)));
+        cosTheta = std::max(-1.0, std::min(1.0, cosTheta));
+        return std::acos(cosTheta);
     }
 };
 


### PR DESCRIPTION
## Summary
- ensure `DistanceGeodesic` clamps cosine values prior to `acos`

## Testing
- `R CMD build --no-build-vignettes .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --no-build-vignettes parallelDist_0.2.6.tar.gz` *(fails: pdflatex missing due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68547dc59780833083f5745f56b47ee2