### PR TITLE
Fix gcov invocation for header coverage

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@ CPPLINT.cfg
 ^\.Rproj\.user$
 .vscode
 install.sh
+^tools$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -125,4 +125,4 @@ jobs:
         if: matrix.config.os == env.R_TEST_OS && matrix.config.r == env.R_RELEASE_VERSION
         run: |
           R CMD INSTALL .
-          Rscript -e "covr::codecov(token = '${{secrets.CODECOV_TOKEN}}')"
+          Rscript tools/run-codecov.R

--- a/tools/gcov-wrapper.sh
+++ b/tools/gcov-wrapper.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+
+# Allow overriding the gcov binary via GCOV_BIN, otherwise use gcov from PATH.
+GCOV_BIN="${GCOV_BIN:-gcov}"
+
+if ! command -v "$GCOV_BIN" >/dev/null 2>&1; then
+  echo "gcov wrapper: unable to find '$GCOV_BIN'" >&2
+  exit 127
+fi
+
+# Resolve repository root from the location of this script.
+REPO_DIR=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+
+cd "$REPO_DIR/src"
+exec "$GCOV_BIN" "$@"

--- a/tools/run-codecov.R
+++ b/tools/run-codecov.R
@@ -1,0 +1,18 @@
+#!/usr/bin/env Rscript
+
+if (!requireNamespace("covr", quietly = TRUE)) {
+  stop("The covr package must be installed to run coverage", call. = FALSE)
+}
+
+wrapper <- normalizePath(file.path("tools", "gcov-wrapper.sh"), winslash = "/", mustWork = TRUE)
+
+old_opts <- options(covr.gcov = wrapper)
+on.exit(options(old_opts), add = TRUE)
+
+token <- Sys.getenv("CODECOV_TOKEN", "")
+
+if (nzchar(token)) {
+  covr::codecov(token = token)
+} else {
+  covr::codecov()
+}


### PR DESCRIPTION
## Summary
- add a gcov wrapper that executes from the package src directory so header files are located
- drive coverage uploads through a helper R script that installs the wrapper and forwards CODECOV_TOKEN
- run the new helper from CI and ignore the tools directory in the package build

## Testing
- not run (R is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68cee2da28a88330aff81848d851bc49